### PR TITLE
Added condition to check if distribution is RHEL

### DIFF
--- a/tasks/disable.yml
+++ b/tasks/disable.yml
@@ -13,6 +13,7 @@
   with_items:
     - regexp: '^proxy_hostname\s*=.*'
     - regexp: '^proxy_port\s*=.*'
+  when: ansible_distribution == "Red Hat Enterprise Linux"
 
 - name: configure yum to not use proxy authentication
   lineinfile:
@@ -31,6 +32,7 @@
   with_items:
     - regexp: '^proxy_user\s*=.*'
     - regexp: '^proxy_password\s*=.*'
+  when: ansible_distribution == "Red Hat Enterprise Linux"
 
 - name: configure the default profile to not use a proxy
   file:

--- a/tasks/disable.yml
+++ b/tasks/disable.yml
@@ -13,7 +13,7 @@
   with_items:
     - regexp: '^proxy_hostname\s*=.*'
     - regexp: '^proxy_port\s*=.*'
-  when: ansible_distribution == "Red Hat Enterprise Linux"
+  when: ansible_distribution == "RedHat"
 
 - name: configure yum to not use proxy authentication
   lineinfile:
@@ -32,7 +32,7 @@
   with_items:
     - regexp: '^proxy_user\s*=.*'
     - regexp: '^proxy_password\s*=.*'
-  when: ansible_distribution == "Red Hat Enterprise Linux"
+  when: ansible_distribution == "RedHat"
 
 - name: configure the default profile to not use a proxy
   file:

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -16,7 +16,7 @@
     - regexp: '^proxy_port\s*=.*'
       line: "proxy_port={{proxy_port}}"
   when:
-    - ansible_distribution == "Red Hat Enterprise Linux"
+    - ansible_distribution == "RedHat"
     - proxy_proto is defined
     - proxy_proto == "http"
 
@@ -43,7 +43,7 @@
       - regexp: '^proxy_password\s*=.*'
         line: "proxy_password={{proxy_pass}}"
     when:
-      - ansible_distribution == "Red Hat Enterprise Linux"
+      - ansible_distribution == "RedHat"
       - proxy_proto is defined
       - proxy_proto == "http"
   when:

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -17,29 +17,35 @@
       line: "proxy_port={{proxy_port}}"
   when: ansible_distribution == "Red Hat Enterprise Linux"
 
-- name: configure yum to use the proxy authentication
-  lineinfile:
-    path: "/etc/yum.conf"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  with_items:
-    - regexp: '^proxy_username\s*=.*'
-      line: "proxy_username={{proxy_user}}"
-    - regexp: '^proxy_password\s*=.*'
-      line: "proxy_password={{proxy_pass}}"
-  when: proxy_auth is defined and proxy_auth
+- block:
+  - name: configure yum to use the proxy authentication
+    lineinfile:
+      path: "/etc/yum.conf"
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+    with_items:
+      - regexp: '^proxy_username\s*=.*'
+        line: "proxy_username={{proxy_user}}"
+      - regexp: '^proxy_password\s*=.*'
+        line: "proxy_password={{proxy_pass}}"
 
-- name: configure RHSM to use the proxy authentication (HTTP-only)
-  lineinfile:
-    path: "/etc/rhsm/rhsm.conf"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  with_items:
-    - regexp: '^proxy_user\s*=.*'
-      line: "proxy_user={{proxy_user}}"
-    - regexp: '^proxy_password\s*=.*'
-      line: "proxy_password={{proxy_pass}}"
-  when: ansible_distribution == "Red Hat Enterprise Linux" and proxy_auth is defined and proxy_auth and proxy_proto is defined and proxy_proto == "http"
+  - name: configure RHSM to use the proxy authentication (HTTP-only)
+    lineinfile:
+      path: "/etc/rhsm/rhsm.conf"
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+    with_items:
+      - regexp: '^proxy_user\s*=.*'
+        line: "proxy_user={{proxy_user}}"
+      - regexp: '^proxy_password\s*=.*'
+        line: "proxy_password={{proxy_pass}}"
+    when:
+      - ansible_distribution == "Red Hat Enterprise Linux"
+      - proxy_proto is defined
+      - proxy_proto == "http"
+  when:
+    - proxy_auth is defined
+    - proxy_auth
 
 - name: configure the default profile to use the proxy
   template:

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -15,6 +15,7 @@
       line: "proxy_hostname={{proxy_address}}"
     - regexp: '^proxy_port\s*=.*'
       line: "proxy_port={{proxy_port}}"
+  when: ansible_distribution == "Red Hat Enterprise Linux"
 
 - name: configure yum to use the proxy authentication
   lineinfile:
@@ -38,7 +39,7 @@
       line: "proxy_user={{proxy_user}}"
     - regexp: '^proxy_password\s*=.*'
       line: "proxy_password={{proxy_pass}}"
-  when: proxy_auth is defined and proxy_auth and proxy_proto is defined and proxy_proto == "http"
+  when: ansible_distribution == "Red Hat Enterprise Linux" and proxy_auth is defined and proxy_auth and proxy_proto is defined and proxy_proto == "http"
 
 - name: configure the default profile to use the proxy
   template:

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -5,7 +5,7 @@
     regexp: '^proxy\s*=.*'
     line: "proxy={{proxy_proto}}://{{proxy_address}}:{{proxy_port}}"
 
-- name: configure RHSM to use the proxy
+- name: configure RHSM to use the proxy (HTTP-only)
   lineinfile:
     path: "/etc/rhsm/rhsm.conf"
     regexp: "{{ item.regexp }}"
@@ -15,7 +15,10 @@
       line: "proxy_hostname={{proxy_address}}"
     - regexp: '^proxy_port\s*=.*'
       line: "proxy_port={{proxy_port}}"
-  when: ansible_distribution == "Red Hat Enterprise Linux"
+  when:
+    - ansible_distribution == "Red Hat Enterprise Linux"
+    - proxy_proto is defined
+    - proxy_proto == "http"
 
 - block:
   - name: configure yum to use the proxy authentication


### PR DESCRIPTION
Added condition to check if distribution is RHEL in the RHSM tasks to avoid errors when executing the role in non RHEL distributions, for example CentOS.