### PR TITLE
Make possible to not manage RedHat package tools

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ proxy_port: ""
 proxy_auth: false
 proxy_user: ""
 proxy_pass: ""
+proxy_redhat: true #configure yum and RHSM to use the proxy
 proxy_whitelist:
   - "127.0.0.1"
   - "localhost"

--- a/tasks/linux/disable.yml
+++ b/tasks/linux/disable.yml
@@ -1,38 +1,40 @@
 ---
-- name: configure yum to not use the proxy
-  lineinfile:
-    path: "/etc/yum.conf"
-    regexp: '^proxy\s*=.*'
-    state: absent
+- block:
+  - name: configure yum to not use the proxy
+    lineinfile:
+      path: "/etc/yum.conf"
+      regexp: '^proxy\s*=.*'
+      state: absent
 
-- name: configure RHSM to not use the proxy
-  lineinfile:
-    path: "/etc/rhsm/rhsm.conf"
-    regexp: "{{ item.regexp }}"
-    state: absent
-  with_items:
-    - regexp: '^proxy_hostname\s*=.*'
-    - regexp: '^proxy_port\s*=.*'
-  when: ansible_distribution == "RedHat"
+  - name: configure RHSM to not use the proxy
+    lineinfile:
+      path: "/etc/rhsm/rhsm.conf"
+      regexp: "{{ item.regexp }}"
+      state: absent
+    with_items:
+      - regexp: '^proxy_hostname\s*=.*'
+      - regexp: '^proxy_port\s*=.*'
+    when: ansible_distribution == "RedHat"
 
-- name: configure yum to not use proxy authentication
-  lineinfile:
-    path: "/etc/yum.conf"
-    regexp: "{{ item.regexp }}"
-    state: absent
-  with_items:
-    - regexp: '^proxy_username\s*=.*'
-    - regexp: '^proxy_password\s*=.*'
+  - name: configure yum to not use proxy authentication
+    lineinfile:
+      path: "/etc/yum.conf"
+      regexp: "{{ item.regexp }}"
+      state: absent
+    with_items:
+      - regexp: '^proxy_username\s*=.*'
+      - regexp: '^proxy_password\s*=.*'
 
-- name: configure RHSM to not use the proxy authentication
-  lineinfile:
-    path: "/etc/rhsm/rhsm.conf"
-    regexp: "{{ item.regexp }}"
-    state: absent
-  with_items:
-    - regexp: '^proxy_user\s*=.*'
-    - regexp: '^proxy_password\s*=.*'
-  when: ansible_distribution == "RedHat"
+  - name: configure RHSM to not use the proxy authentication
+    lineinfile:
+      path: "/etc/rhsm/rhsm.conf"
+      regexp: "{{ item.regexp }}"
+      state: absent
+    with_items:
+      - regexp: '^proxy_user\s*=.*'
+      - regexp: '^proxy_password\s*=.*'
+    when: ansible_distribution == "RedHat"
+  when: proxy_redhat
 
 - name: configure the default profile to not use a proxy
   file:

--- a/tasks/linux/enable.yml
+++ b/tasks/linux/enable.yml
@@ -1,54 +1,56 @@
 ---
-- name: configure yum to use the proxy
-  lineinfile:
-    path: "/etc/yum.conf"
-    regexp: '^proxy\s*=.*'
-    line: "proxy={{proxy_proto}}://{{proxy_address}}:{{proxy_port}}"
-
-- name: configure RHSM to use the proxy (HTTP-only)
-  lineinfile:
-    path: "/etc/rhsm/rhsm.conf"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  with_items:
-    - regexp: '^proxy_hostname\s*=.*'
-      line: "proxy_hostname={{proxy_address}}"
-    - regexp: '^proxy_port\s*=.*'
-      line: "proxy_port={{proxy_port}}"
-  when:
-    - ansible_distribution == "RedHat"
-    - proxy_proto is defined
-    - proxy_proto == "http"
-
 - block:
-  - name: configure yum to use the proxy authentication
+  - name: configure yum to use the proxy
     lineinfile:
       path: "/etc/yum.conf"
-      regexp: "{{ item.regexp }}"
-      line: "{{ item.line }}"
-    with_items:
-      - regexp: '^proxy_username\s*=.*'
-        line: "proxy_username={{proxy_user}}"
-      - regexp: '^proxy_password\s*=.*'
-        line: "proxy_password={{proxy_pass}}"
+      regexp: '^proxy\s*=.*'
+      line: "proxy={{proxy_proto}}://{{proxy_address}}:{{proxy_port}}"
 
-  - name: configure RHSM to use the proxy authentication (HTTP-only)
+  - name: configure RHSM to use the proxy (HTTP-only)
     lineinfile:
       path: "/etc/rhsm/rhsm.conf"
       regexp: "{{ item.regexp }}"
       line: "{{ item.line }}"
     with_items:
-      - regexp: '^proxy_user\s*=.*'
-        line: "proxy_user={{proxy_user}}"
-      - regexp: '^proxy_password\s*=.*'
-        line: "proxy_password={{proxy_pass}}"
+      - regexp: '^proxy_hostname\s*=.*'
+        line: "proxy_hostname={{proxy_address}}"
+      - regexp: '^proxy_port\s*=.*'
+        line: "proxy_port={{proxy_port}}"
     when:
       - ansible_distribution == "RedHat"
       - proxy_proto is defined
       - proxy_proto == "http"
-  when:
-    - proxy_auth is defined
-    - proxy_auth
+
+  - block:
+    - name: configure yum to use the proxy authentication
+      lineinfile:
+        path: "/etc/yum.conf"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
+      with_items:
+        - regexp: '^proxy_username\s*=.*'
+          line: "proxy_username={{proxy_user}}"
+        - regexp: '^proxy_password\s*=.*'
+          line: "proxy_password={{proxy_pass}}"
+
+    - name: configure RHSM to use the proxy authentication (HTTP-only)
+      lineinfile:
+        path: "/etc/rhsm/rhsm.conf"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
+      with_items:
+        - regexp: '^proxy_user\s*=.*'
+          line: "proxy_user={{proxy_user}}"
+        - regexp: '^proxy_password\s*=.*'
+          line: "proxy_password={{proxy_pass}}"
+      when:
+        - ansible_distribution == "RedHat"
+        - proxy_proto is defined
+        - proxy_proto == "http"
+    when:
+      - proxy_auth is defined
+      - proxy_auth
+  when: proxy_redhat
 
 - name: configure the default profile to use the proxy
   template:


### PR DESCRIPTION
This PR enables the user to not manage the RedHat tools (Yum and Red Hat Subscription Manager) with the role. This is useful in environments that implement an independent set of lifecycle managers (eg. Red Hat Satellite) inside their corporate network.