### PR TITLE
Changed proxy_redhat var to false.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ proxy_port: ""
 proxy_auth: false
 proxy_user: ""
 proxy_pass: ""
-proxy_redhat: true #configure yum and RHSM to use the proxy
+proxy_redhat: false #configure yum and RHSM to use the proxy
 proxy_whitelist:
   - "127.0.0.1"
   - "localhost"


### PR DESCRIPTION
Changed proxy_redhat var to false, thinking about general infrastructure, the machines should not use proxy to register in your satellite server. 