### PR TITLE
Configure systemd to use proxy and adds tasks to keep proxy settings when using sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ proxy_proto: "http"
 proxy_address: ""
 proxy_port: ""
 
+# To keep proxy settings when using sudo 
+proxy_sudo: true
+
 # To use proxy with authentication
 proxy_auth: false
 proxy_user: ""

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ proxy_port: ""
 # To keep proxy settings when using sudo 
 proxy_sudo: true
 
+# Configure systemd to use the proxy
+proxy_systemd: false
+
 # To use proxy with authentication
 proxy_auth: false
 proxy_user: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ proxy_port: ""
 # To keep proxy settings when using sudo 
 proxy_sudo: true
 
+# Configure systemd to use the proxy
+proxy_systemd: false
+
 # To use proxy with authentication
 proxy_auth: false
 proxy_user: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@ proxy_proto: "http"
 proxy_address: ""
 proxy_port: ""
 
+# To keep proxy settings when using sudo 
+proxy_sudo: true
+
 # To use proxy with authentication
 proxy_auth: false
 proxy_user: ""

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  systemd:
+    daemon_reload: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
 - name: Reload systemd
   systemd:
     daemon_reload: true
+    daemon_reexec: true

--- a/tasks/linux/disable.yml
+++ b/tasks/linux/disable.yml
@@ -85,7 +85,7 @@
         - NO_PROXY
       when: proxy_systemd_result is changed
       notify: Reload systemd
-
-    - name: Force all notified handlers to run at this point, not waiting for normal sync points
-      meta: flush_handlers
   when: proxy_systemd | bool
+
+- name: Force all notified handlers to run at this point, not waiting for normal sync points
+  meta: flush_handlers

--- a/tasks/linux/disable.yml
+++ b/tasks/linux/disable.yml
@@ -41,3 +41,14 @@
   file:
     path: "/etc/profile.d/proxy.sh"
     state: absent
+
+- name: Ensure that sudo not use the proxy
+  blockinfile:
+    path: /etc/sudoers
+    insertafter: '(^Defaults\s+env_keep)'
+    block: |
+      Defaults    env_keep += "ftp_proxy http_proxy https_proxy no_proxy"
+    marker: "# {mark} - Ansible managed block - Ensure that sudo use the proxy"
+    state: absent
+    validate: /usr/sbin/visudo -cf %s
+  when: proxy_sudo | bool

--- a/tasks/linux/disable.yml
+++ b/tasks/linux/disable.yml
@@ -63,3 +63,29 @@
     - name: Force collect ansible_env facts to unload http_proxy environment variable
       setup:
   when: (proxy_profile_result is changed) or (proxy_sudo_result is changed)
+
+- name: Task block to disable proxy on SystemD
+  block:
+    - name: Configure the systemd to use the proxy
+      template:
+        src: proxy.conf.j2
+        dest: /etc/systemd/system.conf.d/proxy.conf
+        state: absent
+      register: proxy_systemd_result
+
+    - name: Configure the systemd to use the proxy at runtime
+      command: systemctl unset-environment {{ item }}
+      loop:
+        - proxy
+        - http_proxy
+        - https_proxy
+        - HTTP_PROXY
+        - HTTPS_PROXY
+        - no_proxy
+        - NO_PROXY
+      when: proxy_systemd_result is changed
+      notify: Reload systemd
+
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+  when: proxy_systemd | bool

--- a/tasks/linux/disable.yml
+++ b/tasks/linux/disable.yml
@@ -41,6 +41,7 @@
   file:
     path: "/etc/profile.d/proxy.sh"
     state: absent
+  register: proxy_profile_result
 
 - name: Ensure that sudo not use the proxy
   blockinfile:
@@ -51,4 +52,11 @@
     marker: "# {mark} - Ansible managed block - Ensure that sudo use the proxy"
     state: absent
     validate: /usr/sbin/visudo -cf %s
+  register: proxy_sudo_result
   when: proxy_sudo | bool
+
+- name: Force collect ansible_env facts without http_proxy variable
+  setup:
+    filter:
+      - "ansible_env"
+  when: (proxy_profile_result is changed) or (proxy_sudo_result is changed)

--- a/tasks/linux/disable.yml
+++ b/tasks/linux/disable.yml
@@ -55,8 +55,11 @@
   register: proxy_sudo_result
   when: proxy_sudo | bool
 
-- name: Force collect ansible_env facts without http_proxy variable
-  setup:
-    filter:
-      - "ansible_env"
+- name: Force reload gathered facts
+  block:
+    - name: Clear gathered facts from all currently targeted hosts
+      meta: clear_facts
+
+    - name: Force collect ansible_env facts to unload http_proxy environment variable
+      setup:
   when: (proxy_profile_result is changed) or (proxy_sudo_result is changed)

--- a/tasks/linux/disable.yml
+++ b/tasks/linux/disable.yml
@@ -66,14 +66,13 @@
 
 - name: Task block to disable proxy on SystemD
   block:
-    - name: Configure the systemd to use the proxy
-      template:
-        src: proxy.conf.j2
-        dest: /etc/systemd/system.conf.d/proxy.conf
+    - name: Configure the systemd to no use the proxy
+      file:
+        path: /etc/systemd/system.conf.d/proxy.conf
         state: absent
       register: proxy_systemd_result
 
-    - name: Configure the systemd to use the proxy at runtime
+    - name: Configure the systemd to no use the proxy at runtime
       command: systemctl unset-environment {{ item }}
       loop:
         - proxy

--- a/tasks/linux/enable.yml
+++ b/tasks/linux/enable.yml
@@ -81,3 +81,53 @@
     - name: Force collect ansible_env facts to load http_proxy environment variable
       setup:
   when: (proxy_profile_result is changed) or (proxy_sudo_result is changed)
+
+- name: Task block to configure proxy on SystemD
+  block:
+    - name: Create system.conf.d folder
+      file:
+        path: /etc/systemd/system.conf.d
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Set fact proxy address
+      set_fact:
+        proxy_url: "{{ proxy_url_auth if (proxy_auth is defined and proxy_auth | bool) else proxy_url }}"
+      vars:
+        proxy_url_auth: "{{ proxy_proto }}://{{ proxy_user }}:{{ proxy_pass }}@{{ proxy_address }}:{{ proxy_port }}"
+        proxy_url: "{{ proxy_proto }}://{{ proxy_address }}:{{ proxy_port }}"
+
+    - name: Configure the systemd to use the proxy
+      template:
+        src: proxy.conf.j2
+        dest: /etc/systemd/system.conf.d/proxy.conf
+        owner: root
+        group: root
+        mode: 0644
+      register: proxy_systemd_result
+
+    - name: Configure the systemd to use the proxy at runtime
+      command: systemctl set-environment {{ item.key }}={{ item.value }}
+      loop:
+        - key: proxy
+          value: "{{ proxy_url }}"
+        - key: http_proxy
+          value: "{{ proxy_url }}"
+        - key: https_proxy
+          value: "{{ proxy_url }}"
+        - key: HTTP_PROXY
+          value: "{{ proxy_url }}"
+        - key: HTTPS_PROXY
+          value: "{{ proxy_url }}"
+        - key: no_proxy
+          value: "{{ proxy_whitelist | join(',') }}"
+        - key: NO_PROXY
+          value: "{{ proxy_whitelist | join(',') }}"
+      register: proxy_systemd_result is changed
+      notify: Reload systemd
+
+    - name: Force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+  when: proxy_systemd | bool

--- a/tasks/linux/enable.yml
+++ b/tasks/linux/enable.yml
@@ -73,8 +73,11 @@
   register: proxy_sudo_result
   when: proxy_sudo | bool
 
-- name: Force collect ansible_env facts with http_proxy variable
-  setup:
-    filter:
-      - "ansible_env"
+- name: Force reload gathered facts
+  block:
+    - name: Clear gathered facts from all currently targeted hosts
+      meta: clear_facts
+
+    - name: Force collect ansible_env facts to load http_proxy environment variable
+      setup:
   when: (proxy_profile_result is changed) or (proxy_sudo_result is changed)

--- a/tasks/linux/enable.yml
+++ b/tasks/linux/enable.yml
@@ -127,7 +127,7 @@
           value: "{{ proxy_whitelist | join(',') }}"
       register: proxy_systemd_result is changed
       notify: Reload systemd
-
-    - name: Force all notified handlers to run at this point, not waiting for normal sync points
-      meta: flush_handlers
   when: proxy_systemd | bool
+
+- name: Force all notified handlers to run at this point, not waiting for normal sync points
+  meta: flush_handlers

--- a/tasks/linux/enable.yml
+++ b/tasks/linux/enable.yml
@@ -59,6 +59,7 @@
     src: "proxy.profile.j2"
     dest: "/etc/profile.d/proxy.sh"
     mode: "0755"
+  register: proxy_profile_result
 
 - name: Ensure that sudo use the proxy
   blockinfile:
@@ -69,4 +70,11 @@
     marker: "# {mark} - Ansible managed block - Ensure that sudo use the proxy"
     state: present
     validate: /usr/sbin/visudo -cf %s
+  register: proxy_sudo_result
   when: proxy_sudo | bool
+
+- name: Force collect ansible_env facts with http_proxy variable
+  setup:
+    filter:
+      - "ansible_env"
+  when: (proxy_profile_result is changed) or (proxy_sudo_result is changed)

--- a/tasks/linux/enable.yml
+++ b/tasks/linux/enable.yml
@@ -125,7 +125,7 @@
           value: "{{ proxy_whitelist | join(',') }}"
         - key: NO_PROXY
           value: "{{ proxy_whitelist | join(',') }}"
-      register: proxy_systemd_result is changed
+      when: proxy_systemd_result is changed
       notify: Reload systemd
   when: proxy_systemd | bool
 

--- a/tasks/linux/enable.yml
+++ b/tasks/linux/enable.yml
@@ -59,3 +59,14 @@
     src: "proxy.profile.j2"
     dest: "/etc/profile.d/proxy.sh"
     mode: "0755"
+
+- name: Ensure that sudo use the proxy
+  blockinfile:
+    path: /etc/sudoers
+    insertafter: '(^Defaults\s+env_keep)'
+    block: |
+      Defaults    env_keep += "ftp_proxy http_proxy https_proxy no_proxy"
+    marker: "# {mark} - Ansible managed block - Ensure that sudo use the proxy"
+    state: present
+    validate: /usr/sbin/visudo -cf %s
+  when: proxy_sudo | bool

--- a/templates/proxy.conf.j2
+++ b/templates/proxy.conf.j2
@@ -1,0 +1,10 @@
+## {{ ansible_managed }}
+
+[Manager]
+DefaultEnvironment=proxy={{ proxy_url }} \
+    http_proxy={{ proxy_url }} \
+    https_proxy={{ proxy_url }} \
+    HTTP_PROXY={{ proxy_url }} \
+    HTTPS_PROXY={{ proxy_url }} \
+    no_proxy={{ proxy_whitelist | join(",") }} \
+    NO_PROXY={{ proxy_whitelist | join(",") }}


### PR DESCRIPTION
## Motivation and Context
1. This PR add the new feature that configure the proxy settings in systemd.
2. The machines doesn't have using proxy settings with the sudo command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)